### PR TITLE
Add homepage to cabal

### DIFF
--- a/dependent-sum-aeson-orphans.cabal
+++ b/dependent-sum-aeson-orphans.cabal
@@ -5,6 +5,7 @@ license-file:  LICENSE
 author:        Obsidian Systems
 maintainer:    maintainer@obsidian.systems
 copyright:     2020 Obsidian Systems LLC
+homepage:      https://github.com/obsidiansystems/dependent-sum-aeson-orphans
 build-type:    Simple
 cabal-version: >=1.10
 description:   JSON instances for DSum, DMap, and Some.


### PR DESCRIPTION
I assume this is why hackage doesn't have a link to the repo